### PR TITLE
LIKA-498: Hide additional info fields with no value

### DIFF
--- a/ckanext/scheming/templates/scheming/package/resource_read.html
+++ b/ckanext/scheming/templates/scheming/package/resource_read.html
@@ -48,7 +48,7 @@
           {%- for field in schema.resource_fields -%}
             {%- if field.field_name not in exclude_fields
                 and field.display_snippet is not none
-                and res.get('field.field_name', '') != '' -%}
+                and res.get(field.field_name, '') != '' -%}
               <tr>
                 <th scope="row">
                   {{- h.scheming_language_text(field.label) -}}

--- a/ckanext/scheming/templates/scheming/package/resource_read.html
+++ b/ckanext/scheming/templates/scheming/package/resource_read.html
@@ -47,7 +47,8 @@
         {%- block resource_fields -%}
           {%- for field in schema.resource_fields -%}
             {%- if field.field_name not in exclude_fields
-                and field.display_snippet is not none -%}
+                and field.display_snippet is not none
+                and res.get('field.field_name', '') != '' -%}
               <tr>
                 <th scope="row">
                   {{- h.scheming_language_text(field.label) -}}

--- a/ckanext/scheming/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/additional_info.html
@@ -13,7 +13,8 @@
 {% block package_additional_info %}
   {%- for field in schema.dataset_fields -%}
     {%- if field.field_name not in exclude_fields
-        and field.display_snippet is not none -%}
+        and field.display_snippet is not none
+        and pkg_dict.get(field.field_name, '') != ''  -%}
       <tr>
         <th scope="row" class="dataset-label">{{
           h.scheming_language_text(field.label) }}</th>


### PR DESCRIPTION
LIKA content team wanted to hide the unnecessary fields (including the ones without values) in subsystem (dataset) additional info table. I also verified from AV content team that the same change can be made there as well thus this change is here and not in apicatalog