### PR TITLE
Support T as datetime separator in datetime form snippet

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/datetime.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/datetime.html
@@ -5,8 +5,12 @@
 {% if not date is string and not time is string %}
     {% set date = data.get(field.field_name) %}
 
-    {% if date %}
+    {% if date and ' ' in date %}
         {% set parts = data.get(field.field_name).split() %}
+        {% set date = parts[0] %}
+        {% set time = parts[1] %}
+    {% else %}
+        {% set parts = data.get(field.field_name).split('T') %}
         {% set date = parts[0] %}
         {% set time = parts[1] %}
     {% endif %}


### PR DESCRIPTION
ISO8601 datetimes are `yyyy-mm-ddTHH:MM:SS` but form snippet assumes `yyyy-mm-dd HH:MM:SS`. Support both.